### PR TITLE
udpate offset

### DIFF
--- a/sample_config.json
+++ b/sample_config.json
@@ -1,4 +1,6 @@
 {
   "x-api-token": "tap-tapfiliate-token",
-  "date_from": "2018-01-01"
+  "date_from": "2018-01-01",
+  "page_offset_percentage": "2",
+  "date_offset_days": "2"
 }

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,6 +1,6 @@
 {
   "x-api-token": "tap-tapfiliate-token",
   "date_from": "2018-01-01",
-  "page_offset_percentage": "2",
-  "date_offset_days": "2"
+  "page_offset_percentage": 2,
+  "date_offset_days": 2
 }

--- a/tap_tapfiliate/__init__.py
+++ b/tap_tapfiliate/__init__.py
@@ -134,7 +134,7 @@ def daterange(date1, date2):
 
 def generate_dates_to_today(date_from_str:str, config):
     format = '%Y-%m-%d'
-    date_from = datetime.datetime.strptime(date_from_str, format)-timedelta(days=int(config["date_offset_days"]))
+    date_from = datetime.datetime.strptime(date_from_str, format)-timedelta(days=config["date_offset_days"])
     date_to = datetime.datetime.today()
 
     for dt in daterange(date_from, date_to):

--- a/tap_tapfiliate/__init__.py
+++ b/tap_tapfiliate/__init__.py
@@ -134,7 +134,7 @@ def daterange(date1, date2):
 
 def generate_dates_to_today(date_from_str:str):
     format = '%Y-%m-%d'
-    date_from = datetime.datetime.strptime(date_from_str, format)
+    date_from = datetime.datetime.strptime(date_from_str, format)-timedelta(days=2)
     date_to = datetime.datetime.today()
 
     for dt in daterange(date_from, date_to):
@@ -163,6 +163,8 @@ def sync(config, state, catalog):
 
         with singer.metrics.record_counter(stream.tap_stream_id) as counter:
             if bookmark_column == 'page':
+                if int(bookmark_value)>10:
+                    bookmark_value=str(int(int(bookmark_value)*0.98)) #offsetting two percent of pages from the last bookmarked page
                 for page, record in tapfiliate_client.get_sync_endpoints(
                     stream.tap_stream_id, parameters={bookmark_column: bookmark_value}
                 ):

--- a/tap_tapfiliate/__init__.py
+++ b/tap_tapfiliate/__init__.py
@@ -164,7 +164,7 @@ def sync(config, state, catalog):
         with singer.metrics.record_counter(stream.tap_stream_id) as counter:
             if bookmark_column == 'page':
                 if int(bookmark_value)>10:
-                    bookmark_value=str(int(int(bookmark_value) * int(config["page_offset_percentage"])/100)) #offsetting two percent of pages from the last bookmarked page
+                    bookmark_value=str(int(int(bookmark_value) * config["page_offset_percentage"]/100)) # offsetting two percent of pages from the last bookmarked page
                 for page, record in tapfiliate_client.get_sync_endpoints(
                     stream.tap_stream_id, parameters={bookmark_column: bookmark_value}
                 ):


### PR DESCRIPTION
With the current process we see that some records are getting missed. This might be due to some deletions on of records on the tapfiliate side. So this change will offset the state of the streams so that we re-process a bit of previous pages/dates data to make sure no records were missed. 
We have two types of states currently ., one based on page number and the other based on date. For date I made the offset of start date by 2 days(start process from two days before the latest state) and for page I will offset the page number by 2 percent of the latest page number in the state.